### PR TITLE
setuptools-git-versioning is required to get version number at build time

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,4 +24,5 @@ bld.bat text eol=crlf
 /README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true
 build-locally.py linguist-generated=true
+pixi.toml linguist-generated=true
 shippable.yml linguist-generated=true

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "python-kaleido-feedstock"
-version = "3.51.0"  # conda-smithy version used to generate this file
+version = "3.51.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/python-kaleido-feedstock"
 authors = ["@conda-forge/python-kaleido"]
 channels = ["conda-forge"]

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 502d8ba64737924efaf5e94c2736745bcc7c926e6cc535838be36c0fc06330bd
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: ${{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
 
@@ -20,6 +20,7 @@ requirements:
     - python ${{ python_min }}.*
     - pip
     - setuptools
+    - setuptools-git-versioning
   run:
     - python >=${{ python_min }}
     - choreographer >=1.0.5


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)

Without this, the Python level metadata (as seen in `pip list`) gets a default 0.0.0 version number. This breaks plotly, because it's using that metadata to check what version of kaleido is installed.

https://github.com/plotly/Kaleido/issues/359